### PR TITLE
fix(i18n): unify language handling

### DIFF
--- a/modules/common.py
+++ b/modules/common.py
@@ -9,7 +9,7 @@ from modules.config import telegram_start
 from modules.auth_utils import is_admin
 from modules.log_utils import log_async_call
 from modules.inactivity import clear_user_activity
-from modules.i18n import normalize_lang
+from modules.i18n import resolve_user_lang
 from modules.storage import db_get_user_locale
 from modules.media_utils import send_localized_image_with_text
 
@@ -19,8 +19,8 @@ async def handle_start_command(update: Update, context: ContextTypes.DEFAULT_TYP
     user = update.effective_user
     clear_user_activity(user.id)
     username = user.first_name or user.username or "user"
-    lang = db_get_user_locale(user.id)
-    lang = normalize_lang(lang or getattr(user, "language_code", None))
+    user_row = {"locale": db_get_user_locale(user.id)}
+    lang = resolve_user_lang(update, user_row)
     text = render_template(telegram_start.get("template", "start_user.txt"), username=username, lang=lang)
     button_text = telegram_start.get("action_button_text", "Получить доступ")
     keyboard = InlineKeyboardMarkup([[InlineKeyboardButton(text=button_text, callback_data="request_access")]])

--- a/modules/flow.py
+++ b/modules/flow.py
@@ -51,7 +51,8 @@ def build_admin_keyboard(membership_id: str) -> InlineKeyboardMarkup:
 
 
 def _user_lang(update: Update) -> str:
-    return resolve_user_lang(update, {"locale": db_get_user_locale(update.effective_user.id)})
+    user_row = {"locale": db_get_user_locale(update.effective_user.id)}
+    return resolve_user_lang(update, user_row)
 
 
 @log_async_call
@@ -128,7 +129,9 @@ async def handle_idle_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 @log_async_call
 async def handle_unknown_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await update.message.reply_text("Неизвестная команда. Используйте /start")
+    lang = _user_lang(update)
+    text = render_template("unknown_action.txt", lang=lang)
+    await update.message.reply_text(text)
 
 
 # Admin decision handlers ---------------------------------------------

--- a/modules/i18n.py
+++ b/modules/i18n.py
@@ -16,7 +16,7 @@ def normalize_lang(code: str | None) -> str:
     base = code.split("-")[0].lower()
     return base if base in SUPPORTED else DEFAULT_LANG
 
-async def resolve_user_lang(update, user_row) -> str:
+def resolve_user_lang(update, user_row) -> str:
     if user_row and user_row.get("locale") in SUPPORTED:
         return user_row["locale"]
     if not i18n.get("enabled_start_prompt", True):


### PR DESCRIPTION
## Summary
- resolve user language synchronously instead of coroutine
- apply the same resolved language to both text and images
- localize unknown message replies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e8258e084832ca5b2f9c9ebccd8a9