### PR TITLE
fix: rebind members without unique errors and sync locale

### DIFF
--- a/modules/flow.py
+++ b/modules/flow.py
@@ -124,7 +124,18 @@ async def handle_idle_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
     text = render_template(telegram_start.get("template", "start_user.txt"), username=username, lang=lang)
     button_text = telegram_start.get("action_button_text", "Получить доступ")
     keyboard = InlineKeyboardMarkup([[InlineKeyboardButton(text=button_text, callback_data="request_access")]])
-    await update.message.reply_text(text, reply_markup=keyboard)
+    if telegram_start.get("enabled_image", True):
+        await send_localized_image_with_text(
+            bot=context.bot,
+            chat_id=update.effective_chat.id,
+            asset_key="start.image",
+            cfg_section=telegram_start,
+            lang=lang,
+            text=text,
+            reply_markup=keyboard,
+        )
+    else:
+        await update.message.reply_text(text, reply_markup=keyboard)
 
 
 @log_async_call


### PR DESCRIPTION
## Summary
- Rebind membership records to existing Telegram accounts without violating `telegram_id` uniqueness for SQLite and Postgres
- Use consistent language for start flow and localized images
- Add regression tests for member rebind and swap scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e8a7e0730832c88b2318205e5d2c8