### PR TITLE
feat: send post-join message on actual channel join

### DIFF
--- a/modules/db_base.py
+++ b/modules/db_base.py
@@ -87,6 +87,15 @@ class DatabaseAdapter(ABC):
     def mark_warning_sent(self, telegram_id: int) -> None:
         """Mark that expiration warning was sent to member."""
 
+    # -- Post-join helpers -------------------------------------------------
+    @abstractmethod
+    def was_post_join_sent(self, member_id: int) -> bool:
+        """Return True if post-join message was already sent."""
+
+    @abstractmethod
+    def mark_post_join_sent(self, member_id: int) -> None:
+        """Mark that post-join message has been sent."""
+
     # -- Join request links ----------------------------------------------
     @abstractmethod
     def get_join_link(self, chat_id: int) -> Optional[dict[str, Any]]:

--- a/modules/db_postgres_adapter.py
+++ b/modules/db_postgres_adapter.py
@@ -190,7 +190,7 @@ class PostgresAdapter(DatabaseAdapter):
 
     def set_confirmation(self, membership_id: str, is_confirmed: bool, expires_at: datetime | None = None) -> None:
         self._run(
-            "UPDATE members SET is_confirmed=%s, expires_at=%s, warn_sent_at=NULL, grace_notified_at=NULL WHERE membership_id=%s",
+            "UPDATE members SET is_confirmed=%s, expires_at=%s, warn_sent_at=NULL, grace_notified_at=NULL, post_join_sent_at=NULL WHERE membership_id=%s",
             [is_confirmed, expires_at, membership_id],
         )
 
@@ -234,7 +234,7 @@ class PostgresAdapter(DatabaseAdapter):
         self, member_id: int, confirmed: bool, expires_at: datetime | None = None
     ) -> None:
         self._run(
-            "UPDATE members SET is_confirmed=%s, expires_at=%s, warn_sent_at=NULL, grace_notified_at=NULL WHERE telegram_id=%s",
+            "UPDATE members SET is_confirmed=%s, expires_at=%s, warn_sent_at=NULL, grace_notified_at=NULL, post_join_sent_at=NULL WHERE telegram_id=%s",
             [confirmed, expires_at, member_id],
         )
 
@@ -345,6 +345,18 @@ class PostgresAdapter(DatabaseAdapter):
 
     def mark_warning_sent(self, telegram_id: int) -> None:
         self._run("UPDATE members SET warn_sent_at=NOW() WHERE telegram_id=%s", [telegram_id])
+
+    # Post-join helpers -------------------------------------------------
+    def was_post_join_sent(self, member_id: int) -> bool:
+        row = self._run(
+            "SELECT post_join_sent_at FROM members WHERE id=%s",
+            [member_id],
+            fetchone=True,
+        )
+        return bool(row and row["post_join_sent_at"])
+
+    def mark_post_join_sent(self, member_id: int) -> None:
+        self._run("UPDATE members SET post_join_sent_at=NOW() WHERE id=%s", [member_id])
 
     # Join links -------------------------------------------------------
     def get_join_link(self, chat_id: int) -> Optional[dict[str, Any]]:

--- a/modules/db_sqlite_adapter.py
+++ b/modules/db_sqlite_adapter.py
@@ -186,7 +186,7 @@ class SQLiteAdapter(DatabaseAdapter):
     def set_confirmation(self, membership_id: str, is_confirmed: bool, expires_at: datetime | None = None) -> None:
         expires = int(expires_at.timestamp()) if expires_at else None
         self._run(
-            "UPDATE members SET is_confirmed=?, expires_at=?, warn_sent_at=NULL, grace_notified_at=NULL WHERE membership_id=?",
+            "UPDATE members SET is_confirmed=?, expires_at=?, warn_sent_at=NULL, grace_notified_at=NULL, post_join_sent_at=NULL WHERE membership_id=?",
             [int(is_confirmed), expires, membership_id],
         )
 
@@ -249,7 +249,7 @@ class SQLiteAdapter(DatabaseAdapter):
     ) -> None:
         expires = int(expires_at.timestamp()) if expires_at else None
         self._run(
-            "UPDATE members SET is_confirmed=?, expires_at=?, warn_sent_at=NULL, grace_notified_at=NULL WHERE telegram_id=?",
+            "UPDATE members SET is_confirmed=?, expires_at=?, warn_sent_at=NULL, grace_notified_at=NULL, post_join_sent_at=NULL WHERE telegram_id=?",
             [int(confirmed), expires, member_id],
         )
 
@@ -352,6 +352,19 @@ class SQLiteAdapter(DatabaseAdapter):
     def mark_warning_sent(self, telegram_id: int) -> None:
         now = datetime.utcnow().isoformat()
         self._run("UPDATE members SET warn_sent_at=? WHERE telegram_id=?", [now, telegram_id])
+
+    # Post-join helpers -------------------------------------------------
+    def was_post_join_sent(self, member_id: int) -> bool:
+        row = self._run(
+            "SELECT post_join_sent_at FROM members WHERE id=?",
+            [member_id],
+            fetchone=True,
+        )
+        return bool(row and row["post_join_sent_at"])
+
+    def mark_post_join_sent(self, member_id: int) -> None:
+        now = datetime.utcnow().isoformat()
+        self._run("UPDATE members SET post_join_sent_at=? WHERE id=?", [now, member_id])
 
     # Join links -------------------------------------------------------
     def get_join_link(self, chat_id: int) -> Optional[dict[str, Any]]:

--- a/modules/flow.py
+++ b/modules/flow.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
 from telegram.ext import ContextTypes
 
-from modules.config import telegram_start, templates, id_config, admin_buttons, admin_ui, renewal, post_join
+from modules.config import telegram_start, templates, id_config, admin_buttons, admin_ui, renewal
 from modules.storage import (
     db_get_member_by_telegram,
     db_get_member_by_id,
@@ -230,23 +230,6 @@ async def handle_admin_decision(update: Update, context: ContextTypes.DEFAULT_TY
             else:
                 text = render_template(templates.get("links_unavailable", "links_unavailable.txt"), lang=user_lang)
             await context.bot.send_message(chat_id=user_id, text=text, disable_web_page_preview=True)
-            if post_join.get("enabled"):
-                post_text = render_template(post_join.get("template", "post_join.txt"), lang=user_lang)
-                if post_join.get("enabled_image", True):
-                    await send_localized_image_with_text(
-                        bot=context.bot,
-                        chat_id=user_id,
-                        asset_key="post_join.image",
-                        cfg_section=post_join,
-                        lang=user_lang,
-                        text=post_text,
-                    )
-                else:
-                    await context.bot.send_message(
-                        chat_id=user_id,
-                        text=post_text,
-                        parse_mode="HTML",
-                    )
         await query.edit_message_text(render_template("admin_approved.txt", membership_id=membership_id))
     elif action == "decline":
         db_set_confirmation(membership_id, False, None)

--- a/modules/join_approver.py
+++ b/modules/join_approver.py
@@ -5,8 +5,11 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from modules.storage import db_get_member_by_telegram
+from modules.post_join import maybe_send_post_join
+from modules.log_utils import log_async_call
 
 
+@log_async_call
 async def on_join_request(update: Update, context: ContextTypes.DEFAULT_TYPE):
     req = update.chat_join_request
     user_id = req.from_user.id
@@ -25,5 +28,18 @@ async def on_join_request(update: Update, context: ContextTypes.DEFAULT_TYPE):
             ok = expires_dt > datetime.utcnow()
     if ok:
         await context.bot.approve_chat_join_request(chat_id, user_id)
+        await maybe_send_post_join(context.bot, member)
     else:
         await context.bot.decline_chat_join_request(chat_id, user_id)
+
+
+@log_async_call
+async def on_chat_member(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    cmu = update.chat_member
+    old_s = cmu.old_chat_member.status
+    new_s = cmu.new_chat_member.status
+    user = cmu.new_chat_member.user
+    if new_s in ("member", "administrator") and old_s in ("left", "kicked"):
+        member = db_get_member_by_telegram(user.id)
+        if member and member.get("is_confirmed"):
+            await maybe_send_post_join(context.bot, member)

--- a/modules/post_join.py
+++ b/modules/post_join.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from modules.i18n import resolve_user_lang
+from modules.template_engine import render_template
+from modules.media_utils import send_localized_image_with_text
+from modules.storage import (
+    db_get_user_locale,
+    db_was_post_join_sent,
+    db_mark_post_join_sent,
+)
+from modules.config import post_join as POST
+from modules.log_utils import log_async_call
+
+
+@log_async_call
+async def maybe_send_post_join(bot, member_row: dict) -> None:
+    """Send post-join message once after user joins a channel."""
+    if not POST.get("enabled", True):
+        return
+    if db_was_post_join_sent(member_row["id"]):
+        return
+    lang = resolve_user_lang(None, {"locale": db_get_user_locale(member_row["telegram_id"])})
+    text = render_template(POST.get("template", "post_join.txt"), lang=lang)
+    await send_localized_image_with_text(
+        bot,
+        member_row["telegram_id"],
+        asset_key="post_join.image",
+        cfg_section=POST,
+        lang=lang,
+        text=text,
+    )
+    db_mark_post_join_sent(member_row["id"])

--- a/modules/storage.py
+++ b/modules/storage.py
@@ -102,6 +102,16 @@ def db_mark_warning_sent(telegram_id: int) -> None:
 
 
 @log_sync_call
+def db_was_post_join_sent(member_id: int) -> bool:
+    return get_db().was_post_join_sent(member_id)
+
+
+@log_sync_call
+def db_mark_post_join_sent(member_id: int) -> None:
+    get_db().mark_post_join_sent(member_id)
+
+
+@log_sync_call
 def db_get_join_link(chat_id: int):
     return get_db().get_join_link(chat_id)
 

--- a/schema/postgres.sql
+++ b/schema/postgres.sql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS members (
     expires_at TIMESTAMP,
     warn_sent_at TIMESTAMP,
     grace_notified_at TIMESTAMP,
+    post_join_sent_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/schema/sqlite.sql
+++ b/schema/sqlite.sql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS members (
     expires_at INTEGER,
     warn_sent_at TEXT,
     grace_notified_at TEXT,
+    post_join_sent_at TEXT,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (telegram_id) REFERENCES users(telegram_id)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -9,12 +9,13 @@ from telegram.ext import (
     MessageHandler,
     CallbackQueryHandler,
     ChatJoinRequestHandler,
+    ChatMemberHandler,
     filters,
 )
 from rich.console import Console
 
 from modules.routing import route_message, handle_inline_button
-from modules.join_approver import on_join_request
+from modules.join_approver import on_join_request, on_chat_member
 from modules.common import handle_start_command, handle_help_command
 from modules.i18n import cmd_language, on_lang_pick
 from modules.admin_commands import (
@@ -86,6 +87,7 @@ def run_telegram_bot():
     app.add_handler(CallbackQueryHandler(on_lang_pick, pattern=r"^lang:"))
     app.add_handler(CallbackQueryHandler(handle_inline_button))
     app.add_handler(ChatJoinRequestHandler(on_join_request))
+    app.add_handler(ChatMemberHandler(on_chat_member, ChatMemberHandler.CHAT_MEMBER))
 
     console.print("[bold green]Telegram bot is running[/bold green]")
     logger.info("Telegram bot is now polling for messages")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -16,6 +16,10 @@ def test_member_flow(tmp_path):
     member = db.get_member_by_membership_id("123")
     assert member["telegram_id"] == 111
     assert member["username"] == "user"
+    member_id = member["id"]
+    assert not db.was_post_join_sent(member_id)
+    db.mark_post_join_sent(member_id)
+    assert db.was_post_join_sent(member_id)
     db.set_confirmation("123", True, datetime.utcnow() + timedelta(seconds=10))
     member = db.get_member_by_membership_id("123")
     assert member["is_confirmed"] == 1


### PR DESCRIPTION
## Summary
- send post-join message only when a user actually joins a channel
- track post-join delivery in DB to avoid duplicates
- test DB helpers for post-join tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f39a41834832c8ab8fc93d9fbf662