### PR TITLE
feat(i18n): localize inline button texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@
    ```yaml
    start:
      template: start_user.txt
-     action_button_text: "Получить доступ"
+    action_button_text:
+      en: "Get access"
+      ru: "Получить доступ"
      enabled_image: true
      image:
        en: { path: assets/en/start.jpg }
@@ -103,10 +105,25 @@
      granted: access_granted.txt
      denied: access_denied.txt
 
-   admin_interface:
-     approve_template: "Разрешить на {period}"
-     decline_text: "Отклонить"
-     ban_text: "Забанить"
+  admin_interface:
+    approve_template:
+      en: "Approve for {period}"
+      ru: "Разрешить на {period}"
+    decline_text:
+      en: "Decline"
+      ru: "Отклонить"
+    ban_text:
+      en: "Ban"
+      ru: "Забанить"
+    unban_text:
+      en: "Unban"
+      ru: "Разбанить"
+    kick_text:
+      en: "Kick"
+      ru: "Кикнуть"
+    remove_text:
+      en: "Remove"
+      ru: "Удалить"
 
    language_prompt:
      enabled_image: false

--- a/config/membership.yaml
+++ b/config/membership.yaml
@@ -21,11 +21,17 @@ renewal:
   grace_after_expiry_sec: 86400
   user_plans:
     - id: trial_3d
-      label: "Подписаться на пробный период"
+      label:
+        en: "Subscribe for trial period"
+        ru: "Подписаться на пробный период"
       duration_sec: 259200
     - id: month_30
-      label: "Купить подписку на 30 дней"
+      label:
+        en: "Buy 30-day subscription"
+        ru: "Купить подписку на 30 дней"
       duration_sec: 2592000
     - id: lifetime
-      label: "Купить бессрочную подписку"
+      label:
+        en: "Buy lifetime subscription"
+        ru: "Купить бессрочную подписку"
       duration_sec: 0

--- a/config/ui_config.yaml
+++ b/config/ui_config.yaml
@@ -1,6 +1,9 @@
 start:
   template: start_user.txt
-  action_button_text: "Получить доступ"
+  action_button_text:
+    en: "Get access"
+    ru: "Получить доступ"
+    # extend with more locales as needed
   enabled_image: true
   image:
     en: { path: assets/en/start.jpg }
@@ -22,9 +25,24 @@ messages:
   links_unavailable: links_unavailable.txt
 
 admin_interface:
-  approve_template: "Разрешить на {period}"
-  decline_text: "Отклонить"
-  ban_text: "Забанить"
+  approve_template:
+    en: "Approve for {period}"
+    ru: "Разрешить на {period}"
+  decline_text:
+    en: "Decline"
+    ru: "Отклонить"
+  ban_text:
+    en: "Ban"
+    ru: "Забанить"
+  unban_text:
+    en: "Unban"
+    ru: "Разбанить"
+  kick_text:
+    en: "Kick"
+    ru: "Кикнуть"
+  remove_text:
+    en: "Remove"
+    ru: "Удалить"
 
 language_prompt:
   enabled_image: true

--- a/modules/admin_commands.py
+++ b/modules/admin_commands.py
@@ -9,6 +9,7 @@ from telegram.ext import ContextTypes
 
 from modules.auth_utils import is_admin
 from modules.template_engine import render_template
+from modules.config import admin_ui
 from modules.storage import (
     db_get_member_by_membership_id,
     db_get_member_by_telegram,
@@ -28,6 +29,7 @@ from modules.access_control import (
 )
 from modules.time_utils import humanize_period
 from modules.log_utils import log_async_call
+from modules.i18n import get_button_text, DEFAULT_LANG
 
 
 def resolve_member_by_key(key: str | int) -> dict | None:
@@ -127,14 +129,28 @@ async def _build_user_card(bot, member: dict):
         in_channels=in_channels,
         locale=user_locale,
     )
-    keyboard = InlineKeyboardMarkup([
+    keyboard = InlineKeyboardMarkup(
         [
-            InlineKeyboardButton("Ban", callback_data=f"admin:ban:{member['membership_id']}") ,
-            InlineKeyboardButton("Unban", callback_data=f"admin:unban:{member['membership_id']}") ,
-            InlineKeyboardButton("Kick", callback_data=f"admin:kick:{member['membership_id']}") ,
-            InlineKeyboardButton("Remove", callback_data=f"admin:remove:{member['membership_id']}") ,
+            [
+                InlineKeyboardButton(
+                    get_button_text(admin_ui.get("ban_text"), DEFAULT_LANG, "Ban"),
+                    callback_data=f"admin:ban:{member['membership_id']}",
+                ),
+                InlineKeyboardButton(
+                    get_button_text(admin_ui.get("unban_text"), DEFAULT_LANG, "Unban"),
+                    callback_data=f"admin:unban:{member['membership_id']}",
+                ),
+                InlineKeyboardButton(
+                    get_button_text(admin_ui.get("kick_text"), DEFAULT_LANG, "Kick"),
+                    callback_data=f"admin:kick:{member['membership_id']}",
+                ),
+                InlineKeyboardButton(
+                    get_button_text(admin_ui.get("remove_text"), DEFAULT_LANG, "Remove"),
+                    callback_data=f"admin:remove:{member['membership_id']}",
+                ),
+            ]
         ]
-    ])
+    )
     return text, keyboard
 
 

--- a/modules/common.py
+++ b/modules/common.py
@@ -9,7 +9,12 @@ from modules.config import telegram_start, start_language_prompt, i18n as i18n_c
 from modules.auth_utils import is_admin
 from modules.log_utils import log_async_call
 from modules.inactivity import clear_user_activity
-from modules.i18n import resolve_user_lang, send_language_prompt, make_username
+from modules.i18n import (
+    resolve_user_lang,
+    send_language_prompt,
+    make_username,
+    get_button_text,
+)
 from modules.storage import db_get_user_locale
 from modules.media_utils import send_localized_image_with_text
 
@@ -32,8 +37,10 @@ async def handle_start_command(update: Update, context: ContextTypes.DEFAULT_TYP
     lang = resolve_user_lang(update, user_row)
     username = make_username(user, lang)
     text = render_template(telegram_start.get("template", "start_user.txt"), username=username, lang=lang)
-    button_text = telegram_start.get("action_button_text", "Получить доступ")
-    keyboard = InlineKeyboardMarkup([[InlineKeyboardButton(text=button_text, callback_data="request_access")]])
+    button_text = get_button_text(telegram_start.get("action_button_text"), lang, "Get access")
+    keyboard = InlineKeyboardMarkup(
+        [[InlineKeyboardButton(text=button_text, callback_data="request_access")]]
+    )
     context.user_data["state"] = UserState.WAITING_FOR_REQUEST_BUTTON
     if telegram_start.get("enabled_image", True):
         await send_localized_image_with_text(

--- a/modules/i18n.py
+++ b/modules/i18n.py
@@ -12,6 +12,25 @@ SUPPORTED = set(i18n.get("supported_langs", []))
 DEFAULT_LANG = i18n.get("default_lang", "en")
 
 
+def get_button_text(cfg_value, lang: str, fallback: str | None = None) -> str:
+    """Return localized button text from config value.
+
+    cfg_value can be either a plain string or a dict mapping language codes
+    to translations. Fallback order: requested lang -> DEFAULT_LANG -> "en" ->
+    provided fallback -> empty string.
+    """
+    if isinstance(cfg_value, dict):
+        return (
+            cfg_value.get(lang)
+            or cfg_value.get(DEFAULT_LANG)
+            or cfg_value.get("en")
+            or (fallback if fallback is not None else "")
+        )
+    if cfg_value:
+        return cfg_value
+    return fallback or ""
+
+
 def make_username(user, lang: str) -> str:
     first = getattr(user, "first_name", "") or ""
     last = getattr(user, "last_name", "") or ""
@@ -107,6 +126,4 @@ async def on_lang_pick(update, context):
     # На всякий случай fallback — отправить новое сообщение
     else:
         await msg.reply_text(text)
-        
-    if context.user_data.get("state") == UserState.WAITING_FOR_LANGUAGE:
-        await handle_start_command(update, context)
+    await handle_start_command(update, context)

--- a/modules/inactivity.py
+++ b/modules/inactivity.py
@@ -6,7 +6,7 @@ from telegram.ext import ContextTypes
 from modules.template_engine import render_template
 from modules.config import session_timeout, telegram_start
 from modules.storage import db_get_user_locale
-from modules.i18n import normalize_lang, make_username
+from modules.i18n import normalize_lang, make_username, get_button_text
 from modules.states import UserState
 from modules.log_utils import log_async_call
 from modules.logging_config import logger
@@ -38,9 +38,17 @@ async def check_user_inactivity_loop(app) -> None:
                 if send_message:
                     lang = normalize_lang(db_get_user_locale(uid))
                     username = make_username(None, lang)
-                    text = render_template(telegram_start.get("template", "start_user.txt"), username=username, lang=lang)
-                    button_text = telegram_start.get("action_button_text", "Получить доступ")
-                    keyboard = InlineKeyboardMarkup([[InlineKeyboardButton(text=button_text, callback_data="request_access")]])
+                    text = render_template(
+                        telegram_start.get("template", "start_user.txt"),
+                        username=username,
+                        lang=lang,
+                    )
+                    button_text = get_button_text(
+                        telegram_start.get("action_button_text"), lang, "Get access"
+                    )
+                    keyboard = InlineKeyboardMarkup(
+                        [[InlineKeyboardButton(text=button_text, callback_data="request_access")]]
+                    )
                     await context.bot.send_message(chat_id=uid, text=text, reply_markup=keyboard)
                 ud = context.application.user_data.get(uid)
                 if isinstance(ud, dict):

--- a/tests/test_i18n_buttons.py
+++ b/tests/test_i18n_buttons.py
@@ -1,0 +1,12 @@
+from modules.i18n import get_button_text, DEFAULT_LANG
+
+
+def test_get_button_text_basic():
+    cfg = {"en": "Get", "ru": "Получить"}
+    assert get_button_text(cfg, "ru") == "Получить"
+    assert get_button_text(cfg, "de") == cfg[DEFAULT_LANG]
+
+
+def test_get_button_text_fallback():
+    cfg = {"ru": "Получить"}
+    assert get_button_text(cfg, "de", "Get") == "Get"


### PR DESCRIPTION
## Summary
- localize inline button labels via per-language config
- rebuild keyboards on language change and keep callback_data stable
- cover button text fallback logic with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f82207220832c80d11b643e1ac383