### PR TITLE
feat: suppress Telegram service messages

### DIFF
--- a/config/ui_config.yaml
+++ b/config/ui_config.yaml
@@ -65,3 +65,6 @@ post_join:
   image:
     en: { path: assets/en/final.jpg }
     ru: { path: assets/ru/final.jpg }
+
+behavior:
+  suppress_service_messages: true

--- a/modules/config.py
+++ b/modules/config.py
@@ -16,6 +16,7 @@ admin_ui = _ui.get("admin_interface", {})
 language_prompt = _ui.get("language_prompt", {})
 start_language_prompt = _ui.get("start_language_prompt", {})
 post_join = _ui.get("post_join", {})
+behavior = _ui.get("behavior", {})
 
 # Membership rules
 id_config = _mb.get("id", {})

--- a/modules/service_messages.py
+++ b/modules/service_messages.py
@@ -1,0 +1,19 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+from telegram.error import TelegramError
+
+from modules.log_utils import log_async_call
+from modules.states import UserState
+
+
+@log_async_call
+async def suppress_service(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Delete service messages like joins or pins if the feature is enabled."""
+    context.user_data["state"] = UserState.IDLE
+    if not context.bot_data.get("suppress_service_messages", True):
+        return
+    try:
+        await update.effective_message.delete()
+    except TelegramError:
+        # Ignore deletion errors (e.g., insufficient rights)
+        pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ from modules.config import (
     language_prompt,
     start_language_prompt,
     post_join,
+    behavior,
 )
 
 
@@ -34,3 +35,4 @@ def test_config_loaded():
     assert "template" in start_language_prompt
     assert "template" in post_join
     assert "enabled_image" in post_join
+    assert "suppress_service_messages" in behavior


### PR DESCRIPTION
## Summary
- add `behavior.suppress_service_messages` config option
- delete join/leave/pin service messages before other handlers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f89ebcb74832c9228da5935434a92