### PR TITLE
feat(flow): add optional image for ID request

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@
     `renewal_requested_admin`, `links_unavailable`, `session_timeout`.
    - `admin_interface` – подписи для кнопок администратора. Шаблон
      `approve_template` принимает `{period}`.
-   - `language_prompt` – шаблон и картинка для смены языка через `/language`.
+  - `language_prompt` – шаблон и картинка для смены языка через `/language`.
   - `start_language_prompt` – шаблон и картинка для первичного выбора языка на `/start`.
+  - `ask_id_prompt` – запрос ID с опциональной картинкой.
   - `invalid_id_prompt` – уведомление о некорректном ID с опциональной картинкой.
   - `post_join` – сообщение после вступления в чат: шаблон, опциональная
     картинка и флаг `enabled`.
@@ -134,6 +135,10 @@
    start_language_prompt:
      enabled_image: false
      template: start_language_prompt.txt
+
+   ask_id_prompt:
+     enabled_image: false
+     template: ask_id.txt
 
    invalid_id_prompt:
      enabled_image: false

--- a/config/ui_config.yaml
+++ b/config/ui_config.yaml
@@ -59,6 +59,13 @@ start_language_prompt:
     en: { path: assets/en/language.jpg }
     ru: { path: assets/ru/language.jpg }
 
+ask_id_prompt:
+  enabled_image: true
+  template: ask_id.txt
+  image:
+    en: { path: assets/en/id_example.jpg }
+    ru: { path: assets/ru/id_example.jpg }
+
 invalid_id_prompt:
   enabled_image: true
   template: id_invalid.txt

--- a/modules/config.py
+++ b/modules/config.py
@@ -17,6 +17,7 @@ language_prompt = _ui.get("language_prompt", {})
 start_language_prompt = _ui.get("start_language_prompt", {})
 post_join = _ui.get("post_join", {})
 behavior = _ui.get("behavior", {})
+ask_id_prompt = _ui.get("ask_id_prompt", {})
 invalid_id_prompt = _ui.get("invalid_id_prompt", {})
 
 # Membership rules

--- a/modules/flow.py
+++ b/modules/flow.py
@@ -14,6 +14,7 @@ from modules.config import (
     admin_buttons,
     admin_ui,
     renewal,
+    ask_id_prompt,
     invalid_id_prompt,
 )
 from modules.storage import (
@@ -78,8 +79,23 @@ def _user_lang(update: Update) -> str:
 async def handle_request_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
     context.user_data["state"] = UserState.WAITING_FOR_ID
     lang = _user_lang(update)
-    text = render_template(templates.get("ask_id", "ask_id.txt"), lang=lang)
-    await update.callback_query.message.reply_text(text)
+    username = make_username(update.effective_user, lang)
+    text = render_template(
+        ask_id_prompt.get("template", "ask_id.txt"),
+        lang=lang,
+        username=username,
+    )
+    if ask_id_prompt.get("enabled_image"):
+        await send_localized_image_with_text(
+            bot=context.bot,
+            chat_id=update.effective_chat.id,
+            asset_key="ask_id.image",
+            cfg_section=ask_id_prompt,
+            lang=lang,
+            text=text,
+        )
+    else:
+        await update.callback_query.message.reply_text(text, parse_mode="HTML")
 
 
 @log_async_call

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from modules.config import (
     start_language_prompt,
     post_join,
     behavior,
+    ask_id_prompt,
     invalid_id_prompt,
 )
 
@@ -34,6 +35,7 @@ def test_config_loaded():
     assert "en" in i18n_buttons
     assert "template" in language_prompt
     assert "template" in start_language_prompt
+    assert "template" in ask_id_prompt
     assert "template" in invalid_id_prompt
     assert "template" in post_join
     assert "enabled_image" in post_join


### PR DESCRIPTION
## Summary
- allow Send your ID prompt to include localized image
- load ask_id_prompt config section and document in README
- test ask_id_prompt configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f9da00434832c8ed0a3e49146ae7d