### PR TITLE
fix(flow): clear user activity after ID submission

### DIFF
--- a/modules/flow.py
+++ b/modules/flow.py
@@ -176,6 +176,7 @@ async def handle_id_submission(update: Update, context: ContextTypes.DEFAULT_TYP
         template = templates.get("not_found", "id_not_found.txt")
     text = render_template(template, membership_id=raw_id, lang=lang)
     await update.message.reply_text(text, parse_mode="HTML")
+    clear_user_activity(user.id)
     context.user_data["state"] = UserState.IDLE
 
 


### PR DESCRIPTION
## Summary
- clear user inactivity after ID submission to prevent notification loops

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689faf85e910832c840858e37c2d57e9